### PR TITLE
Add `delta` and `delta_token` for a single drive root

### DIFF
--- a/src/drives/manual_request.rs
+++ b/src/drives/manual_request.rs
@@ -8,6 +8,17 @@ impl DrivesIdApiClient {
         path: "/drives/{{RID}}/root/children",
         body: true
     );
+    get!(
+        doc: "Invoke function delta",
+        name: delta,
+        path: "/drives/{{RID}}/root/delta()"
+    );
+    get!(
+        doc: "Invoke function delta",
+        name: delta_token,
+        path: "/drives/{{RID}}/root/delta(token='{{id}}')",
+        params: token
+    );
 }
 
 impl DrivesItemsIdApiClient {


### PR DESCRIPTION
Hej, great work with the 1.0 update. We talked in #354 about delta tokens.

I found one oddity when trying to get the delta  of a drive. There is no `.delta()` in `DrivesIdApiClient` only in  `DrivesItemsPathIdApiClient` which in turn would end up looking like this. 

```
client
  .drive("b!1oEIas-b4U6W99kfSoeuCsWxaE3M8_1Ntd6j7imn15Stw2E6t7n6SYmXmE1-hC75")
  .item_by_path("")
  .get_drive_item_delta()
```

with this addition you can use

```
client
  .drive("id")
  .delta()
```
