### PR TITLE
Making the https_only client configuration option editable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rustls-tls = ["reqwest/rustls-tls", "graph-http/rustls-tls", "graph-oauth/rustls
 brotli = ["reqwest/brotli"]
 deflate = ["reqwest/deflate"]
 trust-dns = ["reqwest/trust-dns"]
-https-not-required = ["graph-http/https-not-required"]
+test-util = ["graph-http/test-util"]
 
 [dev-dependencies]
 bytes = { version = "1.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rustls-tls = ["reqwest/rustls-tls", "graph-http/rustls-tls", "graph-oauth/rustls
 brotli = ["reqwest/brotli"]
 deflate = ["reqwest/deflate"]
 trust-dns = ["reqwest/trust-dns"]
+https-not-required = ["graph-http/https-not-required"]
 
 [dev-dependencies]
 bytes = { version = "1.4.0" }

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -33,4 +33,4 @@ graph-core = { path = "../graph-core" }
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-https-not-required = []
+test-util = []

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -33,3 +33,4 @@ graph-core = { path = "../graph-core" }
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+https-not-required = []

--- a/graph-http/src/client.rs
+++ b/graph-http/src/client.rs
@@ -133,7 +133,7 @@ impl GraphClientConfiguration {
         self
     }
 
-    #[cfg(feature = "https-not-required")]
+    #[cfg(feature = "test-util")]
     pub fn https_only(mut self, https_only: bool) -> GraphClientConfiguration {
         self.config.https_only = https_only;
         self

--- a/graph-http/src/client.rs
+++ b/graph-http/src/client.rs
@@ -133,6 +133,7 @@ impl GraphClientConfiguration {
         self
     }
 
+    #[cfg(feature = "https-not-required")]
     pub fn https_only(mut self, https_only: bool) -> GraphClientConfiguration {
         self.config.https_only = https_only;
         self

--- a/graph-http/src/client.rs
+++ b/graph-http/src/client.rs
@@ -133,6 +133,11 @@ impl GraphClientConfiguration {
         self
     }
 
+    pub fn https_only(mut self, https_only: bool) -> GraphClientConfiguration {
+        self.config.https_only = https_only;
+        self
+    }
+
     pub fn build(self) -> Client {
         let config = self.clone();
         let headers = self.config.headers.clone();


### PR DESCRIPTION
Hey !

I would like to use [Wiremock-rs](https://github.com/LukeMathWalker/wiremock-rs) to mock the usage of this lib in my app, the wiremock-rs does not support https mock server for now (https://github.com/LukeMathWalker/wiremock-rs/issues/58)

With the `use_endpoint` method already existing, this default https_only option is the only piece missing to be able to mock the lib. Do you think this change fits ?

```rust
// Start mock
let mock_server = MockServer::start().await;

// Create Graph client with token pointing to mock server
let mut graph: Graph = GraphClientConfiguration::new()
    .access_token(token)
    .https_only(false)
    .into();
graph.use_endpoint(format!("{}/graph", mock_server.uri()).as_str());

// set the reqest to expect and value to respond with
Mock::given(method("GET"))
        .and(path("/graph/users"))
        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
            "value": []
        })))
        .expect(1)
        .mount(&mock_server)
        .await;

let mock_result = client
  .users()
  .list_user()
  .paging()
  .json::<Value>()
  .await
  .unwrap();

```