### PR TITLE
remove unused `tokio` features

### DIFF
--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -21,5 +21,5 @@ ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0" }
 url = "2"

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -17,7 +17,7 @@ handlebars = "2.0.2"
 http-serde = "1"
 http = "0.2.9"
 reqwest = { version = "0.11.16", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
-ring = "0.16.15"
+ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7.1"
 thiserror = "1"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.27.0" }
 url = { version = "2", features = ["serde"] }
 
 graph-error = { path = "../graph-error"  }

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.21.0"
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-humanize = "0.2.2"
 reqwest = { version = "0.11.16", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
-ring = "0.16.15"
+ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde-aux = "4.1.2"
 serde_json = "1"


### PR DESCRIPTION
I discovered that `graph-rs` pulls in `full` `tokio` features yet doesn't really make use of any of those. This currently blocks usage in `wasm32-wasi` targets amongst some other crates I'm working with.

I ran `build` and `test` and all seems fine. CI will yell when I was wrong :)