### PR TITLE
fix: Add GraphFailure variant for dyn errors

### DIFF
--- a/graph-error/src/graph_failure.rs
+++ b/graph-error/src/graph_failure.rs
@@ -90,6 +90,9 @@ pub enum GraphFailure {
 
     #[error("{0:#?}")]
     JsonWebToken(#[from] jsonwebtoken::errors::Error),
+
+    #[error("{0:#?}")]
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 impl GraphFailure {
@@ -166,11 +169,5 @@ impl From<AuthExecutionError> for GraphFailure {
             }
             AuthExecutionError::JsonWebToken(error) => GraphFailure::JsonWebToken(error),
         }
-    }
-}
-
-impl From<Box<dyn Error + Send + Sync>> for GraphFailure {
-    fn from(value: Box<dyn Error + Send + Sync>) -> Self {
-        value.into()
     }
 }


### PR DESCRIPTION
Fixes #506 

I fixed it by adding a variant to `GraphFailure` for `Box<dyn Error + Send + Sync>`. This was the easiest way to fix it. Since `GraphFailure` is `pub` this changes the API and probably needs a semver bump though.

Feel free to discard this PR if you prefer a different solution, but I'm going to use it in my project in the mean time until an official fix is released.