### PR TITLE
Disable onenote tests due to changed permissions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,6 @@ required-features = ["interactive-auth", "openssl"]
 name = "interactive_auth"
 path = "examples/interactive_auth/main.rs"
 required-features = ["interactive-auth"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/graph-core/Cargo.toml
+++ b/graph-core/Cargo.toml
@@ -37,3 +37,6 @@ brotli = ["reqwest/brotli"]
 deflate = ["reqwest/deflate"]
 trust-dns = ["reqwest/trust-dns"]
 socks = ["reqwest/socks"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -28,3 +28,6 @@ tokio = { version = "1.25.0", features = ["full"] }
 url = "2"
 x509-parser = "0.15.0"
 uuid = { version = "1.3.1" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -38,3 +38,6 @@ deflate = ["reqwest/deflate", "graph-core/deflate"]
 trust-dns = ["reqwest/trust-dns", "graph-core/trust-dns"]
 socks = ["reqwest/socks", "graph-core/socks"]
 test-util = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -58,3 +58,6 @@ interactive-auth = ["dep:wry", "dep:tao"]
 name = "x509_certificate_tests"
 path = "src/identity/credentials/x509_certificate.rs"
 required-features = ["openssl"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tests/onenote_request.rs
+++ b/tests/onenote_request.rs
@@ -10,7 +10,7 @@ use test_tools::support::cleanup::AsyncCleanUp;
 
 #[tokio::test]
 async fn list_get_notebooks_and_sections() {
-    if Environment::is_appveyor() || Environment::is_local() {
+    if Environment::is_appveyor() || Environment::is_github() {
         return;
     }
 


### PR DESCRIPTION
- Disables onenote tests due to Microsoft changing who can call the onenote APIs (delegated vs application)
- Enable all features for docs