### PR TITLE
Replace `futures` with `futures-util` with no default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ http = { version = "1", default-features = false }
 
 [dev-dependencies]
 bytes = { version = "1.4.0" }
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 http = { workspace = true }
 lazy_static = "1.4"
 tokio = { version = "1.27.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```
 
-To use [stream](#streaming) features add the [futures](https://crates.io/crates/futures) crate:
+To use [stream](#streaming) features add the [futures-util](https://crates.io/crates/futures-util) crate:
 
 ```toml
-futures = "0.3"
+futures_util = { version = "0.3", default-features = false }
 ```
 
-And import `futures::StreamExt`.
+And import `futures_util::StreamExt`.
 
 ```rust
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_rs_sdk::*;
 ```
 
@@ -370,7 +370,7 @@ stream the next link responses or use a channel receiver to get the responses.
 Streaming is only available using the async client.
 
 ```rust
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_rs_sdk::*;
 
 static ACCESS_TOKEN: &str = "ACCESS_TOKEN";

--- a/examples/paging/delta.rs
+++ b/examples/paging/delta.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_rs_sdk::*;
 
 static ACCESS_TOKEN: &str = "ACCESS_TOKEN";

--- a/examples/paging/stream.rs
+++ b/examples/paging/stream.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_rs_sdk::*;
 
 static ACCESS_TOKEN: &str = "ACCESS_TOKEN";

--- a/examples/upload_session/stream_upload_session.rs
+++ b/examples/upload_session/stream_upload_session.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BytesMut};
 use graph_rs_sdk::http::ResponseExt;
 use graph_rs_sdk::*;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 // Stream bytes to a file in OneDrive
 // See https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online

--- a/examples/users/todos/tasks.rs
+++ b/examples/users/todos/tasks.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_rs_sdk::error::GraphResult;
 use graph_rs_sdk::GraphClient;
 use std::collections::VecDeque;

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://github.com/sreeise/graph-rs-sdk"
 async-stream = "0.3"
 async-trait = "0.1.35"
 bytes = { version = "1.4.0", features = ["serde"] }
-futures = "0.3.28"
 http = { workspace = true }
 percent-encoding = "2"
 reqwest = { workspace = true, default-features=false, features = ["json", "gzip", "blocking", "stream"] }
@@ -22,7 +21,7 @@ serde_urlencoded = "0.7.1"
 tokio = { version = "1.27.0", features = ["full", "tracing"] }
 url = { version = "2", features = ["serde"] }
 tower = { version = "0.4.13", features = ["limit", "retry", "timeout", "util"] }
-futures-util = "0.3.30"
+futures-util = { version = "0.3.30", default-features = false }
 
 graph-error = { path = "../graph-error"  }
 graph-core = { path = "../graph-core", default-features = false }

--- a/graph-http/src/io_tools.rs
+++ b/graph-http/src/io_tools.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_error::io_error::{AsyncIoError, ThreadedIoError};
 use std::{
     fs,

--- a/graph-http/src/request_handler.rs
+++ b/graph-http/src/request_handler.rs
@@ -4,7 +4,7 @@ use crate::internal::{
     RequestComponents,
 };
 use async_stream::try_stream;
-use futures::Stream;
+use futures_util::Stream;
 use graph_error::{AuthExecutionResult, ErrorMessage, GraphFailure, GraphResult};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::{Request, Response};

--- a/graph-http/src/upload_session/upload_session_task.rs
+++ b/graph-http/src/upload_session/upload_session_task.rs
@@ -2,7 +2,7 @@ use crate::traits::AsyncIterator;
 use crate::upload_session::RangeIter;
 use async_stream::try_stream;
 use async_trait::async_trait;
-use futures::Stream;
+use futures_util::Stream;
 use graph_error::{GraphFailure, GraphResult};
 use reqwest::header::HeaderMap;
 use reqwest::RequestBuilder;
@@ -107,7 +107,7 @@ impl UploadSession {
     /// # Example
     /// ```rust,ignore
     /// use graph_rs_sdk::*;
-    /// use futures::stream::StreamExt;
+    /// use futures_util::stream::StreamExt;
     /// use std::fs::OpenOptions;
     ///
     /// static ACCESS_TOKEN: &str = "ACCESS_TOKEN";

--- a/test-tools/Cargo.toml
+++ b/test-tools/Cargo.toml
@@ -9,8 +9,7 @@ description = "Microsoft Graph Api Client"
 publish = false
 
 [dependencies]
-anyhow = { version = "1.0.69", features = ["backtrace"]}
-futures = "0.3"
+anyhow = { version = "1.0.69", features = ["backtrace"] }
 from_as = "0.2.0"
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"

--- a/test-tools/src/support/cleanup.rs
+++ b/test-tools/src/support/cleanup.rs
@@ -49,7 +49,7 @@ impl AsyncCleanUp {
     pub fn new_remove_existing(path: &str) -> AsyncCleanUp {
         let path = Path::new(path);
         if path.exists() {
-            futures::executor::block_on(tokio::fs::remove_file(path)).unwrap();
+            std::fs::remove_file(path).unwrap();
         }
         AsyncCleanUp::default()
     }
@@ -64,7 +64,7 @@ impl Drop for AsyncCleanUp {
         for s in &self.rm_f {
             let path = Path::new(s.as_str());
             if path.exists() {
-                futures::executor::block_on(tokio::fs::remove_file(path)).unwrap();
+                std::fs::remove_file(path).unwrap();
             }
         }
     }

--- a/tests/async_concurrency.rs
+++ b/tests/async_concurrency.rs
@@ -1,4 +1,4 @@
-use futures::stream::{self, StreamExt};
+use futures_util::stream::{self, StreamExt};
 use graph_http::traits::ODataNextLink;
 use graph_rs_sdk::*;
 use serde::Deserialize;

--- a/tests/paging.rs
+++ b/tests/paging.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::collections::VecDeque;
 use test_tools::oauth_request::{Environment, DEFAULT_CLIENT_CREDENTIALS_MUTEX4};
 

--- a/tests/upload_session_request.rs
+++ b/tests/upload_session_request.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use graph_error::{GraphFailure, GraphResult};
 use graph_http::api_impl::UploadSession;
 use graph_http::traits::ResponseExt;


### PR DESCRIPTION
This replaces `futures` with `futures-util`. `futures` re-exports the `futures-util` API plus adds a few more things that this crate never uses, so making the switch reduces the dependency tree.

I've also replaced two occurrences of `futures::executor::block_on(tokio::fs::remove_file(path)).unwrap();` in `test-tools` with std APIs, which didn't make sense because tokio expects it's own method to be called from it's own runtime. Also [`tokio::fs::remove_file`](https://docs.rs/tokio/1.48.0/src/tokio/fs/remove_file.rs.html#13-16) spawns `std::fs::remove_file` on a blocking thread, so we may as well call the std API directly with no indirection.