### PR TITLE
Replace `handlebars` with manual URL templating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ workspace = true
 unsafe_code = "forbid"
 
 [dependencies]
-handlebars = "2.0.4" # TODO: Update to 4
 lazy_static = "1.4.0"
 reqwest = { workspace = true, default-features=false, features = ["json", "gzip", "blocking", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/graph-codegen/Cargo.toml
+++ b/graph-codegen/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = "1"
 serde_yaml = "0.9.17"
 strum = { version = "0.21", features = ["derive"] }
 either = { version = "1.6.1", features = ["serde"] }
-handlebars = "2.0.4"
 
 graph-http = { path = "../graph-http" }
 graph-core = { path = "../graph-core" }

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["authentication", "web-programming::http-client"]
 
 [dependencies]
 base64 = "0.21.0"
-handlebars = "2.0.2"
 http = { workspace = true }
 jsonwebtoken = "9.1.0"
 reqwest = { workspace = true, default-features=false, features = ["json", "gzip", "blocking", "stream"] }

--- a/graph-error/src/graph_failure.rs
+++ b/graph-error/src/graph_failure.rs
@@ -44,12 +44,6 @@ pub enum GraphFailure {
     #[error("{0:#?}")]
     GraphRsError(#[from] GraphRsError),
 
-    #[error("{0:#?}")]
-    HandlebarsRenderError(#[from] handlebars::RenderError),
-
-    #[error("{0:?}")]
-    HandlebarsTemplateRenderError(#[from] handlebars::TemplateRenderError),
-
     #[error("Crypto Error (Unknown)")]
     CryptoError,
 

--- a/src/client/api_macros/api_client.rs
+++ b/src/client/api_macros/api_client.rs
@@ -13,7 +13,7 @@ macro_rules! api_client {
         pub struct $name {
             pub(crate) client: graph_http::api_impl::Client,
             pub(crate) resource_config: graph_http::api_impl::ResourceConfig,
-            registry: handlebars::Handlebars,
+            path_renderer: crate::client::common::PathRenderer,
         }
 
         impl $name {
@@ -21,12 +21,12 @@ macro_rules! api_client {
             pub(crate) fn new(
                 client: graph_http::api_impl::Client,
                 resource_config: graph_http::api_impl::ResourceConfig,
-                registry: handlebars::Handlebars,
+                path_renderer: crate::client::common::PathRenderer,
             ) -> $name {
                 $name {
                     client,
                     resource_config,
-                    registry,
+                    path_renderer,
                 }
             }
         }
@@ -41,9 +41,7 @@ macro_rules! api_client {
                 path: S,
                 path_params_map: &serde_json::Value,
             ) -> GraphResult<String> {
-                self.registry
-                    .render_template(path.as_ref(), path_params_map)
-                    .map_err(GraphFailure::from)
+                Ok(self.path_renderer.render(path.as_ref(), path_params_map))
             }
         }
 

--- a/src/client/api_macros/api_client_link.rs
+++ b/src/client/api_macros/api_client_link.rs
@@ -19,7 +19,7 @@ macro_rules! api_client_impl_link {
                     self.endpoint.clone(),
                     resource_identity,
                 ),
-                Handlebars::new(),
+                PathRenderer::new(),
             )
         }
     };
@@ -32,7 +32,7 @@ macro_rules! api_client_impl_link {
                     self.endpoint.clone(),
                     $resource_identity,
                 ),
-                Handlebars::new(),
+                PathRenderer::new(),
             )
         }
     };
@@ -42,25 +42,25 @@ macro_rules! api_client_id_impl_link {
     ($name:ident, $return_type:ty) => {
         pub fn $name<S: AsRef<str>>(&self, id: S) -> $return_type {
             let resource_identity = <$return_type as ResourceIdentifier>::resource_identifier();
-            let (resource_config, registry) =
-                ResourceProvisioner::config_and_registry_with_id_and_url(
+            let (resource_config, path_renderer) =
+                ResourceProvisioner::config_and_renderer_with_id_and_url(
                     id.as_ref(),
                     self.endpoint.clone(),
                     resource_identity,
                 );
-            <$return_type>::new(self.client.clone(), resource_config, registry)
+            <$return_type>::new(self.client.clone(), resource_config, path_renderer)
         }
     };
 
     ($name:ident, $return_type:ty, $resource_identity:expr) => {
         pub fn $name<S: AsRef<str>>(&self, id: S) -> $return_type {
-            let (resource_config, registry) =
-                ResourceProvisioner::config_and_registry_with_id_and_url(
+            let (resource_config, path_renderer) =
+                ResourceProvisioner::config_and_renderer_with_id_and_url(
                     id.as_ref(),
                     self.endpoint.clone(),
                     $resource_identity,
                 );
-            <$return_type>::new(self.client.clone(), resource_config, registry)
+            <$return_type>::new(self.client.clone(), resource_config, path_renderer)
         }
     };
 }
@@ -82,7 +82,7 @@ macro_rules! api_client_link {
 
             resource_config.resource_identity_id = None;
             resource_config.resource_identity = resource_identity;
-            <$return_type>::new(self.client.clone(), resource_config, Handlebars::new())
+            <$return_type>::new(self.client.clone(), resource_config, PathRenderer::new())
         }
     };
 
@@ -101,7 +101,7 @@ macro_rules! api_client_link {
 
             resource_config.resource_identity_id = None;
             resource_config.resource_identity = $resource_identity;
-            <$return_type>::new(self.client.clone(), resource_config, Handlebars::new())
+            <$return_type>::new(self.client.clone(), resource_config, PathRenderer::new())
         }
     };
 
@@ -118,7 +118,7 @@ macro_rules! api_client_link {
 
             resource_config.resource_identity_id = None;
             resource_config.resource_identity = $resource_identity;
-            <$return_type>::new(self.client.clone(), resource_config, Handlebars::new())
+            <$return_type>::new(self.client.clone(), resource_config, PathRenderer::new())
         }
     };
 
@@ -149,7 +149,7 @@ macro_rules! api_client_link_id {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id_str),
+                ResourceProvisioner::path_renderer_with_id(id_str),
             )
         }
     };
@@ -173,7 +173,7 @@ macro_rules! api_client_link_id {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id_str),
+                ResourceProvisioner::path_renderer_with_id(id_str),
             )
         }
     };
@@ -195,7 +195,7 @@ macro_rules! api_client_link_id {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id_str),
+                ResourceProvisioner::path_renderer_with_id(id_str),
             )
         }
     };
@@ -209,7 +209,7 @@ macro_rules! resource_id_tunnel {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id.as_ref()),
+                ResourceProvisioner::path_renderer_with_id(id.as_ref()),
             )
         }
     };
@@ -223,7 +223,7 @@ macro_rules! resource_id_tunnel {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id_str),
+                ResourceProvisioner::path_renderer_with_id(id_str),
             )
         }
     };
@@ -247,7 +247,7 @@ macro_rules! resource_id_tunnel {
             <$return_type>::new(
                 self.client.clone(),
                 resource_config,
-                ResourceProvisioner::registry_with_id(id_str),
+                ResourceProvisioner::path_renderer_with_id(id_str),
             )
         }
     };

--- a/src/client/common/resource_provisioner.rs
+++ b/src/client/common/resource_provisioner.rs
@@ -1,7 +1,48 @@
 use graph_core::resource::ResourceIdentity;
 use graph_http::api_impl::ResourceConfig;
-use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext};
 use url::Url;
+
+/// Simple path renderer that replaces `{{RID}}` with a resource ID
+/// and `{{key}}` patterns with values from a JSON object.
+#[derive(Clone, Default)]
+pub struct PathRenderer {
+    rid: Option<String>,
+}
+
+impl PathRenderer {
+    pub fn new() -> Self {
+        Self { rid: None }
+    }
+
+    pub fn with_rid<S: Into<String>>(rid: S) -> Self {
+        Self {
+            rid: Some(rid.into()),
+        }
+    }
+
+    /// Render a path template by replacing `{{RID}}` with the stored resource ID
+    /// and `{{key}}` patterns with values from the params JSON object.
+    pub fn render(&self, template: &str, params: &serde_json::Value) -> String {
+        let mut result = template.to_string();
+
+        // Replace {{RID}} with the resource ID if present
+        if let Some(ref rid) = self.rid {
+            result = result.replace("{{RID}}", rid);
+        }
+
+        // Replace {{key}} patterns with values from params
+        if let Some(obj) = params.as_object() {
+            for (key, value) in obj {
+                let placeholder = format!("{{{{{}}}}}", key);
+                if let Some(s) = value.as_str() {
+                    result = result.replace(&placeholder, s);
+                }
+            }
+        }
+
+        result
+    }
+}
 
 pub(crate) struct ResourceProvisioner;
 
@@ -21,38 +62,22 @@ impl ResourceProvisioner {
         ResourceConfig::new(resource_identity, url, Some(id.into()))
     }
 
-    pub(crate) fn registry_with_id<ID: ToString>(id: ID) -> Handlebars {
-        let mut registry = Handlebars::new();
-        let id_owned = id.to_string();
-        registry.register_helper(
-            "RID",
-            Box::new(
-                move |_: &Helper,
-                      _: &Handlebars,
-                      _: &Context,
-                      _: &mut RenderContext,
-                      out: &mut dyn Output|
-                      -> HelperResult {
-                    out.write(&id_owned)?;
-                    Ok(())
-                },
-            ),
-        );
-        registry
+    pub(crate) fn path_renderer_with_id<ID: ToString>(id: ID) -> PathRenderer {
+        PathRenderer::with_rid(id.to_string())
     }
 
-    pub(crate) fn config_and_registry_with_id_and_url<ID: ToString>(
+    pub(crate) fn config_and_renderer_with_id_and_url<ID: ToString>(
         id: ID,
         url: Url,
         resource_identity: ResourceIdentity,
-    ) -> (ResourceConfig, Handlebars) {
+    ) -> (ResourceConfig, PathRenderer) {
         (
             ResourceProvisioner::resource_config_with_id_and_url(
                 id.to_string(),
                 url,
                 resource_identity,
             ),
-            ResourceProvisioner::registry_with_id(id.to_string()),
+            ResourceProvisioner::path_renderer_with_id(id.to_string()),
         )
     }
 }

--- a/src/client/graph.rs
+++ b/src/client/graph.rs
@@ -539,7 +539,7 @@ impl GraphClient {
                 self.endpoint.clone(),
                 ResourceIdentity::Batch,
             ),
-            Handlebars::new(),
+            PathRenderer::new(),
         )
         .batch(batch)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,6 @@ pub mod header {
 }
 
 pub(crate) mod api_default_imports {
-    pub(crate) use handlebars::*;
     pub(crate) use reqwest::Method;
     pub(crate) use url::Url;
 
@@ -297,5 +296,6 @@ pub(crate) mod api_default_imports {
     pub(crate) use graph_error::*;
     pub(crate) use graph_http::api_impl::*;
 
+    pub(crate) use crate::client::common::PathRenderer;
     pub(crate) use crate::client::{map_errors, map_parameters, ResourceProvisioner};
 }


### PR DESCRIPTION
This project uses `handlebars` to construct URLs. This is overkill, and can be done with a small manual implementation.