### PR TITLE
Reduce `tokio` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ bytes = { version = "1.4.0" }
 futures = "0.3"
 http = { workspace = true }
 lazy_static = "1.4"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
 warp = { version = "0.3.5" }
 webbrowser = "0.8.7"
 anyhow = "1.0.69"

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -21,7 +21,7 @@ ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["rt", "sync", "time"] }
 url = "2"
 uuid = { version = "1.3.1" }
 

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = { workspace = true, default-features=false, features = ["json", "gzip"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7.1"
-tokio = { version = "1.27.0", features = ["full", "tracing"] }
+tokio = { version = "1.27.0", features = ["rt", "sync", "time", "fs", "io-util"] }
 url = { version = "2", features = ["serde"] }
 tower = { version = "0.4.13", features = ["limit", "retry", "timeout", "util"] }
 futures-util = "0.3.30"

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -37,7 +37,7 @@ url = { version = "2", features = ["serde"] }
 time = { version = "0.3.10", features = ["local-offset", "serde"] }
 wry = { version = "0.37.0", optional = true }
 uuid = { version = "1.3.1", features = ["v4", "serde"] }
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.27.0", features = ["rt", "sync", "time"] }
 tower = { version = "0.4.13", features = ["limit", "retry", "timeout", "util"] }
 tracing = "0.1.37"
 

--- a/test-tools/Cargo.toml
+++ b/test-tools/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8"
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.7.2"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["rt", "sync", "fs"] }
 url = "2"
 
 graph-core = { path = "../graph-core" }


### PR DESCRIPTION
This reduces the `tokio` features to only the ones that get used.

This is best practice, as explained in the tokio docs https://docs.rs/tokio/1.49.0/tokio/#authoring-applications